### PR TITLE
feat: Make 'not in region' placeholder message configurable

### DIFF
--- a/src/main/java/ca/xef5000/quantumcraft/QuantumCraft.java
+++ b/src/main/java/ca/xef5000/quantumcraft/QuantumCraft.java
@@ -1,5 +1,6 @@
 package ca.xef5000.quantumcraft;
 
+import ca.xef5000.quantumcraft.expansion.QuantumCraftExpansion;
 import ca.xef5000.quantumcraft.commands.QuantumCraftCommand;
 import ca.xef5000.quantumcraft.config.RegionConfig;
 import ca.xef5000.quantumcraft.listeners.BlockListener;
@@ -65,6 +66,14 @@ public final class QuantumCraft extends JavaPlugin {
 
         // Start automatic state management
         autoStateManager.start();
+
+        // Register PlaceholderAPI expansion
+        if (getServer().getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            new QuantumCraftExpansion(this).register();
+            getLogger().info("Successfully registered PlaceholderAPI expansion.");
+        } else {
+            getLogger().info("PlaceholderAPI not found, QuantumCraft placeholders will not be available.");
+        }
 
         getLogger().info("QuantumCraft has been enabled!");
         getLogger().info("Quantum superposition system initialized - reality is now optional!");

--- a/src/main/java/ca/xef5000/quantumcraft/expansion/QuantumCraftExpansion.java
+++ b/src/main/java/ca/xef5000/quantumcraft/expansion/QuantumCraftExpansion.java
@@ -76,7 +76,7 @@ public class QuantumCraftExpansion extends PlaceholderExpansion {
         }
 
         if ("region_state".equalsIgnoreCase(identifier)) {
-            RegionState playerState = playerStateManager.getCurrentState(player, currentRegion);
+            RegionState playerState = playerStateManager.getPlayerRegionState(player, currentRegion);
             if (playerState != null) {
                 return playerState.getName();
             } else {

--- a/src/main/java/ca/xef5000/quantumcraft/expansion/QuantumCraftExpansion.java
+++ b/src/main/java/ca/xef5000/quantumcraft/expansion/QuantumCraftExpansion.java
@@ -1,0 +1,99 @@
+package ca.xef5000.quantumcraft.expansion;
+
+import ca.xef5000.quantumcraft.QuantumCraft;
+import ca.xef5000.quantumcraft.player.PlayerStateManager;
+import ca.xef5000.quantumcraft.region.QuantumRegion;
+import ca.xef5000.quantumcraft.region.RegionManager;
+import ca.xef5000.quantumcraft.region.RegionState;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class QuantumCraftExpansion extends PlaceholderExpansion {
+
+    private final QuantumCraft plugin;
+
+    public QuantumCraftExpansion(QuantumCraft plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "quantumcraft";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        List<String> authors = plugin.getDescription().getAuthors();
+        return authors != null && !authors.isEmpty() ? String.join(", ", authors) : "Unknown";
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public boolean canRegister() {
+        return true;
+    }
+
+    @Override
+    public String onRequest(OfflinePlayer offlinePlayer, @NotNull String identifier) {
+        if (offlinePlayer == null || !offlinePlayer.isOnline()) {
+            return null;
+        }
+
+        Player player = offlinePlayer.getPlayer();
+        if (player == null) {
+            return null;
+        }
+
+        RegionManager regionManager = plugin.getRegionManager();
+        PlayerStateManager playerStateManager = plugin.getPlayerStateManager();
+
+        List<QuantumRegion> regions = regionManager.getRegionsAt(player.getLocation());
+
+        if (regions.isEmpty()) {
+            // Player is not in any QuantumCraft region.
+            // Return the configured message for any placeholder from this expansion.
+            return plugin.getConfig().getString("placeholders.not_in_region_message", "&7Not in a quantum region");
+        }
+
+        // Player is in at least one region. Use the first one found for simplicity.
+        QuantumRegion currentRegion = regions.get(0);
+
+        if ("region".equalsIgnoreCase(identifier)) {
+            return currentRegion.getName();
+        }
+
+        if ("region_state".equalsIgnoreCase(identifier)) {
+            RegionState playerState = playerStateManager.getCurrentState(player, currentRegion);
+            if (playerState != null) {
+                return playerState.getName();
+            } else {
+                // Fallback to the region's default state name
+                RegionState defaultState = currentRegion.getState(currentRegion.getDefaultStateName());
+                if (defaultState != null) {
+                    return defaultState.getName();
+                }
+            }
+            // If state is still somehow not determined (e.g., default state missing or misconfigured)
+            // You could make "Unknown State" configurable too, similar to "not_in_region_message"
+            return plugin.getConfig().getString("placeholders.unknown_state_message", "Unknown State");
+        }
+
+        // Identifier is not "region" or "region_state".
+        // Since the player IS in a region, this is an unknown placeholder for this expansion.
+        // Returning null allows PlaceholderAPI to handle it (e.g., by showing the raw placeholder).
+        return null;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -53,3 +53,8 @@ defaults:
 
   # Automatically capture state when creating regions
   auto-capture-on-create: true
+
+# Placeholder settings
+placeholders:
+  # Message to display for region placeholders when a player is not inside any quantum region
+  not_in_region_message: "&7Not in a quantum region"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -58,3 +58,4 @@ defaults:
 placeholders:
   # Message to display for region placeholders when a player is not inside any quantum region
   not_in_region_message: "&7Not in a quantum region"
+  unknown_state_message: "&7Unknown quantum state"


### PR DESCRIPTION
Implements the ability to customize the message displayed by QuantumCraft placeholders when a player is not within any defined quantum region.

- Added `placeholders.not_in_region_message` to `config.yml` (defaulting to "&7Not in a quantum region").
- Updated `QuantumCraftExpansion` to use this configured message.
- Also added a configurable `placeholders.unknown_state_message` for cases where a player's state in a region cannot be determined.

This improves your experience for persistent displays (e.g., scoreboards) where placeholders are always visible.